### PR TITLE
Fix: Leaflet map controls overlapping navbar

### DIFF
--- a/static/css/bloodconnect.css
+++ b/static/css/bloodconnect.css
@@ -47,7 +47,7 @@ h1, h2, h3, h4, h5, h6 { font-weight: 700; line-height: 1.2; }
   backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--border);
   padding: 14px 0;
-  z-index: 1000;
+  z-index: 1050;
 }
 
 .brand-icon {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,7 +60,7 @@ img { max-width: 100%; height: auto; }
 .navbar {
     position: fixed;
     top: 0; left: 0; right: 0;
-    z-index: 1000;
+    z-index: 1050;
     background: rgba(15,17,23,0.9);
     backdrop-filter: blur(20px);
     border-bottom: 1px solid var(--border);


### PR DESCRIPTION
## Problem
Leaflet's zoom controls (+ / −) were rendering on top of the navbar because both shared z-index: 1000.

## Fix
Raised navbar z-index to 1050 in `main.css` and `bloodconnect.css` above Leaflet's default of 1000.

## Screenshots

| Before | After |
| --- | ---- |
| <img width="743" height="700" alt="image" src="https://github.com/user-attachments/assets/c4968404-7065-4277-91c3-fda3383c49a1" />| <img width="682" height="715" alt="image" src="https://github.com/user-attachments/assets/c2865139-c126-4849-8437-92ff8ae91e9e" /> |


Fixes #28 