### PR TITLE
docs: add CONTRIBUTING.md and fix duplicate keyword bug in compatibility tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing to BloodConnect 🩸
+
+Thank you for your interest in contributing to **BloodConnect**! Your support is vital in making this platform more robust and reliable during medical emergencies.
+
+This document outlines the workflows, standards, and setup instructions to help you make successful contributions.
+
+---
+
+## 🧭 Code of Conduct
+
+We expect all contributors to adhere to a respectful and inclusive code of conduct. Please treat other community members with empathy, kindness, and respect.
+
+---
+
+## 🛠️ Local Development Setup
+
+To run BloodConnect on your local system, follow these steps:
+
+### 1. Prerequisites
+Ensure you have the following installed:
+- **Python 3.10+**
+- **pip** (Python package installer)
+- **Virtualenv** (or Python's built-in `venv` module)
+
+### 2. Fork and Clone
+1. Fork the BloodConnect repository on GitHub by clicking the **Fork** button.
+2. Clone your forked repository locally:
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/Blood-Connect-By-ChronalLabs.git
+   cd Blood-Connect-By-ChronalLabs
+   ```
+
+### 3. Create a Virtual Environment
+Initialize a local virtual environment:
+```bash
+python3 -m venv venv
+```
+Activate the environment:
+- **macOS and Linux:**
+  ```bash
+  source venv/bin/activate
+  ```
+- **Windows (CMD):**
+  ```cmd
+  venv\Scripts\activate.bat
+  ```
+- **Windows (PowerShell):**
+  ```powershell
+  venv\Scripts\Activate.ps1
+  ```
+
+### 4. Install Dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### 5. Configure Environment Variables
+Create a local `.env` configuration file from the example template:
+```bash
+cp .env.example .env
+```
+Open `.env` and configure your settings:
+- Update the `SECRET_KEY` with a secure random key.
+- Set `DEBUG=True` for local development.
+
+### 6. Run Database Migrations
+Initialize the SQLite database and run the Django migrations:
+```bash
+python manage.py makemigrations users donors seekers hospitals blood_requests
+python manage.py migrate
+```
+
+### 7. Create a Superuser
+Create an admin account to access the Django admin panel (`/admin/`):
+```bash
+python manage.py createsuperuser
+```
+
+### 8. Collect Static Files
+Generate static file directories for local testing:
+```bash
+python manage.py collectstatic
+```
+
+### 9. Start the Development Server
+```bash
+python manage.py runserver
+```
+Visit **http://127.0.0.1:8000** in your browser to see the live app!
+
+---
+
+## 🧪 Running Tests
+
+Always run tests before pushing code or submitting a Pull Request.
+
+Run the entire Django test suite:
+```bash
+python manage.py test
+```
+
+To run a specific test file (for example, the blood compatibility tests):
+```bash
+python manage.py test blood_requests.tests.test_compatibility
+```
+
+---
+
+## 🌿 Git Branching Workflow
+
+We follow structured conventions for branch names and commit messages.
+
+### Branch Naming Convention
+Please create a new branch from `main` using one of the following prefixes:
+
+| Branch Prefix | Purpose | Example |
+| :--- | :--- | :--- |
+| `feat/` | Adding a new feature | `feat/hospital-dashboard` |
+| `fix/` | Fixing a bug | `fix/compatibility-test-city` |
+| `docs/` | Documentation improvements | `docs/add-contributing-guide` |
+| `refactor/` | Code refactoring (no functional changes) | `refactor/blood-matching-logic` |
+| `chore/` | Build scripts, tasks, dependencies, etc. | `chore/update-readme` |
+
+### Commit Message Guidelines
+Keep your commit messages atomic, descriptive, and in the imperative mood:
+- **Good:** `feat: add donor availability status toggle`
+- **Good:** `fix: resolve duplicate keyword error in compatibility tests`
+- **Bad:** `fixed bug` or `updates`
+
+---
+
+## 🚀 Submitting a Pull Request (PR)
+
+Once you are ready to submit your changes, follow these steps:
+
+1. **Commit and Push:**
+   Commit your changes and push your branch to your GitHub fork:
+   ```bash
+   git push origin <your-branch-name>
+   ```
+2. **Open the PR:**
+   Go to the original BloodConnect repository on GitHub. You should see a prompt to open a Pull Request. Click **Compare & pull request**.
+3. **Fill Out the PR Description:**
+   - Clearly describe what changes were made.
+   - Reference any relevant issues (e.g. `Closes #37`).
+   - Mention what manual or automated testing was performed.
+4. **Review Process:**
+   Project maintainers will review your code. Please address any comments or requested changes in a timely manner. Once approved, your PR will be merged into the `main` branch!
+
+---
+
+Thank you again for contributing to **BloodConnect**! Let's save lives together! 🩸❤️

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **BloodConnect** is a production-ready web platform connecting Blood Donors, Seekers, and Hospitals during emergencies.
 
+Want to contribute? Check out our [Contributing Guide](CONTRIBUTING.md) to get started!
+
 ---
 
 ## 📋 Tech Stack
@@ -203,6 +205,12 @@ GOOGLE_SHEETS_CREDENTIALS=https://script.google.com/macros/s/YOUR_ID/exec
 - **Theme**: Dark health-tech
 - **Fonts**: Syne (headings) + Plus Jakarta Sans (body)
 - **Components**: Bootstrap 5 + Custom CSS
+
+---
+
+## 👥 Contributing
+
+We love contributions! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to fork the repository, set up local development, run tests, and submit a pull request.
 
 ---
 

--- a/blood_requests/tests/test_compatibility.py
+++ b/blood_requests/tests/test_compatibility.py
@@ -326,19 +326,20 @@ class DonorNotificationTests(TestCase):
         return user, profile
 
     def _create_request(self, blood_group='A', rh_factor='+', **request_kwargs):
-        return BloodRequest.objects.create(
-            requester=self.seeker,
-            patient_name='Notification Patient',
-            blood_group=blood_group,
-            rh_factor=rh_factor,
-            units_required=1,
-            hospital_name='City Hospital',
-            hospital_address='Main Road',
-            hospital_contact='9999999999',
-            city='Mumbai',
-            status='open',
-            **request_kwargs,
-        )
+        defaults = {
+            'requester': self.seeker,
+            'patient_name': 'Notification Patient',
+            'blood_group': blood_group,
+            'rh_factor': rh_factor,
+            'units_required': 1,
+            'hospital_name': 'City Hospital',
+            'hospital_address': 'Main Road',
+            'hospital_contact': '9999999999',
+            'city': 'Mumbai',
+            'status': 'open',
+        }
+        defaults.update(request_kwargs)
+        return BloodRequest.objects.create(**defaults)
 
     def test_notifies_only_eligible_compatible_donors(self):
         eligible_user, _ = self._create_donor('eligible_o_neg', 'O', '-', email='eligible@example.com')


### PR DESCRIPTION
## Description
This pull request addresses the lack of onboarding documentation for new contributors (resolving #37). It creates a comprehensive CONTRIBUTING.md guide at the root of the repository, embeds relevant references to it in the README.md, and fixes a bug in the compatibility test suite where duplicate keyword arguments caused execution failure.

## Related Issue
Closes #37

## 🛠️ Changes Made
New Contributing Guide (CONTRIBUTING.md):

- Added detailed local development setup instructions (venv, packages, env variables, Django migrations, superuser creation, and dev server).
- Documented branch naming conventions (feat/, fix/, docs/, refactor/, chore/) and commit guidelines.
- Outlined instructions on how to run tests and submit pull requests.
- README Enhancements (README.md):

- Added a quick contributing call-to-action link under the main header.
- Appended a dedicated "👥 Contributing" section linking directly to CONTRIBUTING.md.
- Test Suite Bug Fix (blood_requests/tests/test_compatibility.py):

- Resolved a TypeError: django.db.models.query.QuerySet.create() got multiple values for keyword argument 'city' error.
- Refactored _create_request to construct a default attribute dictionary and safely merge custom **request_kwargs prior to model instantiation.