### PR TITLE
Add SSE chat streaming for donor conversations

### DIFF
--- a/blood_requests/tests/test_chat.py
+++ b/blood_requests/tests/test_chat.py
@@ -101,6 +101,10 @@ class SecureChatTests(TestCase):
         response = self.client.post(reverse('chat_messages', args=[self.response.id]), {'message': 'Hack!'})
         self.assertEqual(response.status_code, 403)
 
+        # External user trying to open the live stream
+        response = self.client.get(reverse('chat_stream', args=[self.response.id]))
+        self.assertEqual(response.status_code, 403)
+
     def test_messages_api_get_and_post(self):
         """Verify get and post endpoints for message coordination."""
         self.client.force_login(self.donor)
@@ -144,6 +148,24 @@ class SecureChatTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['messages']), 1)
         self.assertEqual(response.json()['messages'][0]['message'], 'Thank you so much!')
+
+    def test_chat_stream_emits_sse_messages(self):
+        """Verify the live stream endpoint emits SSE-formatted chat payloads."""
+        ChatMessage.objects.create(
+            donor_response=self.response,
+            sender=self.seeker,
+            message='Live stream test'
+        )
+
+        self.client.force_login(self.donor)
+        response = self.client.get(reverse('chat_stream', args=[self.response.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+
+        first_chunk = next(iter(response.streaming_content))
+        self.assertIn(b"event: message", first_chunk)
+        self.assertIn(b"Live stream test", first_chunk)
+        response.close()
 
     def test_unread_message_counting_and_marking_read(self):
         """Verify unread counts are calculated correctly and marked as read upon viewing."""
@@ -192,4 +214,3 @@ class SecureChatTests(TestCase):
         self.assertEqual(len(response.context['chat_rooms']), 1)
         self.assertEqual(response.context['chat_rooms'][0]['unread_count'], 1)
         self.assertEqual(response.context['chat_rooms'][0]['last_message'].message, 'Global message test')
-

--- a/blood_requests/urls.py
+++ b/blood_requests/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path("api/requests.json", views.requests_json, name="requests_json"),
     path("chat/<int:response_id>/", views.chat_room, name="chat_room"),
     path("chat/<int:response_id>/messages/", views.chat_messages, name="chat_messages"),
+    path("chat/<int:response_id>/stream/", views.chat_stream, name="chat_stream"),
     path("chats/", views.chat_list, name="chat_list"),
 ]

--- a/blood_requests/views.py
+++ b/blood_requests/views.py
@@ -1,10 +1,11 @@
 from django.shortcuts import render, get_object_or_404
-from django.http import JsonResponse
+from django.http import JsonResponse, StreamingHttpResponse
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 from .models import BloodRequest, DonorResponse
 import json
+import time
 
 
 def request_list(request):
@@ -77,6 +78,17 @@ def requests_json(request):
     return JsonResponse(list(requests_qs), safe=False)
 
 
+def _serialize_chat_message(msg, user):
+    return {
+        "id": msg.id,
+        "sender_username": msg.sender.username,
+        "sender_name": msg.sender.get_full_name() or msg.sender.username,
+        "is_me": msg.sender == user,
+        "message": msg.message,
+        "created_at": timezone.localtime(msg.created_at).strftime("%I:%M %p"),
+    }
+
+
 @login_required
 def chat_room(request, response_id):
     donor_response = get_object_or_404(DonorResponse, id=response_id)
@@ -109,7 +121,7 @@ def chat_messages(request, response_id):
 
     if request.method == "GET":
         last_id = request.GET.get("last_id")
-        messages_qs = donor_response.chat_messages.all()
+        messages_qs = donor_response.chat_messages.select_related("sender").all()
         if last_id:
             try:
                 messages_qs = messages_qs.filter(id__gt=int(last_id))
@@ -119,16 +131,7 @@ def chat_messages(request, response_id):
         # Mark other sender's messages as read upon being fetched
         donor_response.chat_messages.filter(is_read=False).exclude(sender=request.user).update(is_read=True)
 
-        data = []
-        for msg in messages_qs:
-            data.append({
-                "id": msg.id,
-                "sender_username": msg.sender.username,
-                "sender_name": msg.sender.get_full_name() or msg.sender.username,
-                "is_me": msg.sender == request.user,
-                "message": msg.message,
-                "created_at": timezone.localtime(msg.created_at).strftime("%I:%M %p"),
-            })
+        data = [_serialize_chat_message(msg, request.user) for msg in messages_qs]
         return JsonResponse({"messages": data}, safe=False)
 
     elif request.method == "POST":
@@ -152,16 +155,52 @@ def chat_messages(request, response_id):
             message=message_text
         )
 
-        return JsonResponse({
-            "id": msg.id,
-            "sender_username": msg.sender.username,
-            "sender_name": msg.sender.get_full_name() or msg.sender.username,
-            "is_me": True,
-            "message": msg.message,
-            "created_at": timezone.localtime(msg.created_at).strftime("%I:%M %p"),
-        })
+        return JsonResponse(_serialize_chat_message(msg, request.user))
 
     return JsonResponse({"error": "Method not allowed."}, status=405)
+
+
+@login_required
+def chat_stream(request, response_id):
+    donor_response = get_object_or_404(DonorResponse, id=response_id)
+    seeker = donor_response.blood_request.requester
+    donor = donor_response.donor
+
+    if request.user != seeker and request.user != donor:
+        raise PermissionDenied("You do not have access to this chat room.")
+
+    last_id = request.headers.get("Last-Event-ID") or request.GET.get("last_id")
+    try:
+        last_id = int(last_id) if last_id is not None else 0
+    except ValueError:
+        last_id = 0
+
+    donor_response.chat_messages.filter(is_read=False).exclude(sender=request.user).update(is_read=True)
+
+    def event_stream():
+        nonlocal last_id
+        idle_cycles = 0
+        while True:
+            new_messages = list(
+                donor_response.chat_messages.filter(id__gt=last_id).select_related("sender").order_by("id")
+            )
+            if new_messages:
+                idle_cycles = 0
+                for msg in new_messages:
+                    last_id = msg.id
+                    payload = json.dumps(_serialize_chat_message(msg, request.user))
+                    yield f"id: {msg.id}\nevent: message\ndata: {payload}\n\n"
+            else:
+                idle_cycles += 1
+                yield ": keep-alive\n\n"
+            if idle_cycles >= 30:
+                idle_cycles = 0
+            time.sleep(1)
+
+    response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    response["X-Accel-Buffering"] = "no"
+    return response
 
 
 @login_required
@@ -184,4 +223,3 @@ def chat_list(request):
         })
         
     return render(request, "requests/chat_list.html", {"chat_rooms": chat_rooms})
-

--- a/templates/requests/chat_room.html
+++ b/templates/requests/chat_room.html
@@ -396,6 +396,9 @@
             `;
         }
 
+        const streamUrl = `/requests/chat/${responseId}/stream/`;
+        let messageStream = null;
+
         // Fetch messages from Server
         function fetchMessages() {
             const url = `/requests/chat/${responseId}/messages/?last_id=${lastMessageId}`;
@@ -444,6 +447,52 @@
                     }
                 })
                 .catch(err => console.error("Error fetching messages:", err));
+        }
+
+        function connectMessageStream() {
+            if (messageStream) {
+                messageStream.close();
+            }
+
+            const url = `${streamUrl}?last_id=${lastMessageId}`;
+            messageStream = new EventSource(url);
+
+            messageStream.addEventListener("message", function(event) {
+                try {
+                    const msg = JSON.parse(event.data);
+
+                    if (knownMessageIds.has(msg.id)) {
+                        return;
+                    }
+
+                    knownMessageIds.add(msg.id);
+                    emptyState.style.display = "none";
+                    chatBody.insertAdjacentHTML('beforeend', createMessageBubble(msg));
+                    if (msg.id > lastMessageId) {
+                        lastMessageId = msg.id;
+                    }
+
+                    const isScrolledUp = chatBody.scrollHeight - chatBody.scrollTop - chatBody.clientHeight >= 150;
+                    if (!msg.is_me) {
+                        playChime();
+                        startTitleFlash();
+                        if (isScrolledUp && !isFirstLoad) {
+                            scrollToast.classList.add("show");
+                        }
+                    }
+
+                    if (isFirstLoad || !isScrolledUp) {
+                        scrollToBottom();
+                    }
+                    isFirstLoad = false;
+                } catch (err) {
+                    console.error("Error parsing streamed message:", err);
+                }
+            });
+
+            messageStream.onerror = function(err) {
+                console.warn("Message stream disconnected, relying on EventSource reconnect.", err);
+            };
         }
 
         // Scroll chat to the absolute bottom
@@ -505,13 +554,14 @@
             }
         });
 
-        // Initial Load and Polling interval
+        // Initial load and live stream connection
         fetchMessages();
-        const pollInterval = setInterval(fetchMessages, 3000);
+        connectMessageStream();
 
-        // Clear interval on window unload to optimize browser memory
         window.addEventListener("beforeunload", () => {
-            clearInterval(pollInterval);
+            if (messageStream) {
+                messageStream.close();
+            }
         });
     });
 </script>


### PR DESCRIPTION
## Summary\n- Add a live SSE endpoint for donor chat rooms\n- Switch the chat room UI from 3-second polling to EventSource\n- Reuse one serializer for polling, posting, and streaming payloads\n- Cover the new stream endpoint with access control and SSE tests\n\n## Validation\n- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py test blood_requests.tests.test_chat -v 2\n- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py test blood_requests -v 1\n\nCloses #66