### PR TITLE
Default DEBUG to false in production settings

### DIFF
--- a/bloodconnect/settings.py
+++ b/bloodconnect/settings.py
@@ -16,7 +16,10 @@ SECRET_KEY = config('SECRET_KEY', default='django-insecure-bloodconnect-dev-key-
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config('DEBUG', default=True, cast=bool)
+DEBUG = config('DEBUG', default=False, cast=bool)
+
+if os.getenv('RENDER') and DEBUG:
+    raise RuntimeError('DEBUG must be False on Render deployments.')
 
 
 # ALLOWED_HOSTS: local dev, plus any Render hostname you'll use


### PR DESCRIPTION
## Summary\n- Change DEBUG to default to False instead of True\n- Fail loudly on Render if DEBUG is left enabled\n- Preserve local development by allowing explicit DEBUG=True in the environment\n\n## Validation\n- /Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py check\n\nCloses #74