### PR TITLE
restrict donor search access

### DIFF
--- a/blood_requests/migrations/0006_merge_20260601_1214.py
+++ b/blood_requests/migrations/0006_merge_20260601_1214.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blood_requests', '0004_alter_bloodrequest_latitude_and_more'),
+        ('blood_requests', '0006_alter_bloodrequest_latitude_and_more'),
         ('blood_requests', '0004_bloodrequest_linked_hospital'),
         ('blood_requests', '0005_chatmessage_is_read'),
     ]

--- a/blood_requests/migrations/0006_merge_20260601_1830.py
+++ b/blood_requests/migrations/0006_merge_20260601_1830.py
@@ -6,9 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blood_requests', '0004_alter_bloodrequest_latitude_and_more'),
-        ('blood_requests', '0004_bloodrequest_linked_hospital'),
-        ('blood_requests', '0005_chatmessage_is_read'),
+        ('blood_requests', '0006_merge_20260601_1214'),
     ]
 
     operations = [

--- a/donors/tests.py
+++ b/donors/tests.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from users.models import CustomUser
+
+
+class DonorSearchAccessTests(TestCase):
+    """Donor search should only be available to authenticated users."""
+
+    def setUp(self):
+        self.search_url = reverse("search_donors")
+
+    def test_anonymous_users_are_redirected_to_login(self):
+        response = self.client.get(self.search_url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f"/users/login/?next={self.search_url}")
+
+    def test_authenticated_users_can_open_search(self):
+        user = CustomUser.objects.create_user(
+            username="donor_search_user",
+            password="TestPass123!",
+            role="donor",
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(self.search_url)
+
+        self.assertEqual(response.status_code, 200)

--- a/donors/views.py
+++ b/donors/views.py
@@ -150,6 +150,7 @@ def respond_to_request(request, request_id):
     return redirect("donor_dashboard")
 
 
+@login_required
 def search_donors(request):
     """Public donor search"""
     blood_group = request.GET.get("blood_group", "")


### PR DESCRIPTION
## Summary
- Restrict donor search to authenticated users with `@login_required`
- Add a regression test proving anonymous users are redirected to the login page while authenticated users can open search
- Repair the `blood_requests` migration graph so Django test setup can run in this checkout

## Why
`/donors/search/` exposed donor names and phone numbers to anonymous visitors. That made it easy to harvest personal contact data without any login.

The local test database was also blocked by stale merge migration dependencies in `blood_requests`, so I repaired those merge nodes to point at the actual migration chain present in this repo.

## Validation
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile donors/views.py donors/tests.py blood_requests/migrations/0006_merge_20260601_1214.py blood_requests/migrations/0006_merge_20260601_1830.py`
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 manage.py test donors.tests.DonorSearchAccessTests --verbosity 2`
- `git diff --check`

Closes #75
