### PR TITLE
protect cancel request with POST

### DIFF
--- a/blood_requests/migrations/0006_merge_20260601_1214.py
+++ b/blood_requests/migrations/0006_merge_20260601_1214.py
@@ -6,9 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blood_requests', '0004_alter_bloodrequest_latitude_and_more'),
-        ('blood_requests', '0004_bloodrequest_linked_hospital'),
-        ('blood_requests', '0005_chatmessage_is_read'),
+        ('blood_requests', '0006_alter_bloodrequest_latitude_and_more'),
     ]
 
     operations = [

--- a/blood_requests/migrations/0006_merge_20260601_1830.py
+++ b/blood_requests/migrations/0006_merge_20260601_1830.py
@@ -6,9 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blood_requests', '0004_alter_bloodrequest_latitude_and_more'),
-        ('blood_requests', '0004_bloodrequest_linked_hospital'),
-        ('blood_requests', '0005_chatmessage_is_read'),
+        ('blood_requests', '0006_merge_20260601_1214'),
     ]
 
     operations = [

--- a/seekers/tests.py
+++ b/seekers/tests.py
@@ -1,0 +1,54 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from blood_requests.models import BloodRequest
+
+
+User = get_user_model()
+
+
+class CancelRequestSecurityTests(TestCase):
+    def setUp(self):
+        self.seeker = User.objects.create_user(
+            username="seeker1",
+            password="password123",
+            role="seeker",
+            city="Mumbai",
+        )
+        self.other_user = User.objects.create_user(
+            username="donor1",
+            password="password123",
+            role="donor",
+            city="Mumbai",
+        )
+        self.blood_request = BloodRequest.objects.create(
+            requester=self.seeker,
+            patient_name="Test Patient",
+            patient_age=30,
+            blood_group="A",
+            rh_factor="+",
+            units_required=2,
+            hospital_name="General Hospital",
+            hospital_address="Main Street",
+            city="Mumbai",
+            urgency_level="urgent",
+        )
+
+    def test_get_request_does_not_cancel_request(self):
+        self.client.force_login(self.seeker)
+
+        response = self.client.get(reverse("cancel_request", args=[self.blood_request.id]))
+
+        self.blood_request.refresh_from_db()
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(self.blood_request.status, "open")
+
+    def test_post_request_cancels_request(self):
+        self.client.force_login(self.seeker)
+
+        response = self.client.post(reverse("cancel_request", args=[self.blood_request.id]))
+
+        self.blood_request.refresh_from_db()
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.blood_request.status, "cancelled")

--- a/seekers/views.py
+++ b/seekers/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
+from django.views.decorators.http import require_POST
 from .models import SeekerProfile
 from .forms import BloodRequestForm, DonorSearchForm
 from donors.models import DonorProfile
@@ -59,6 +60,7 @@ def my_requests(request):
 
 
 @login_required
+@require_POST
 def cancel_request(request, request_id):
     if request.user.role != "seeker":
         messages.error(request, "Access denied.")

--- a/templates/seekers/my_requests.html
+++ b/templates/seekers/my_requests.html
@@ -20,8 +20,11 @@
             <div class="text-end">
                 <span class="status-badge status-{{ req.status }} mb-2 d-block">{{ req.get_status_display }}</span>
                 {% if req.status == 'open' %}
-                <a href="{% url 'cancel_request' req.id %}" class="btn btn-outline-danger btn-xs"
-                   onclick="return confirm('Cancel this request?')">Cancel</a>
+                <form method="post" action="{% url 'cancel_request' req.id %}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-outline-danger btn-xs"
+                            onclick="return confirm('Cancel this request?')">Cancel</button>
+                </form>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Convert the seeker request cancellation action from a state-changing GET link to a CSRF-protected POST form.
- Add a regression test that proves GET requests no longer cancel a request while POST still works.

## Why
- A GET cancel endpoint can be triggered accidentally or by a malicious third party, which makes request cancellation too easy to invoke without intent.

## Validation
- `git diff --check`
- `python manage.py test seekers.tests.CancelRequestSecurityTests --verbosity 2`

## Notes
- The branch also carries the existing BloodConnect migration-graph repair needed for local Django test execution.

Closes #84
