### PR TITLE
strengthen registration password policy

### DIFF
--- a/blood_requests/migrations/0006_merge_20260601_1214.py
+++ b/blood_requests/migrations/0006_merge_20260601_1214.py
@@ -6,9 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blood_requests', '0004_alter_bloodrequest_latitude_and_more'),
-        ('blood_requests', '0004_bloodrequest_linked_hospital'),
-        ('blood_requests', '0005_chatmessage_is_read'),
+        ('blood_requests', '0006_alter_bloodrequest_latitude_and_more'),
     ]
 
     operations = [

--- a/blood_requests/migrations/0006_merge_20260601_1830.py
+++ b/blood_requests/migrations/0006_merge_20260601_1830.py
@@ -6,9 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('blood_requests', '0004_alter_bloodrequest_latitude_and_more'),
-        ('blood_requests', '0004_bloodrequest_linked_hospital'),
-        ('blood_requests', '0005_chatmessage_is_read'),
+        ('blood_requests', '0006_merge_20260601_1214'),
     ]
 
     operations = [

--- a/users/forms.py
+++ b/users/forms.py
@@ -113,7 +113,7 @@ class UserRegistrationForm(UserCreationForm):
         ]
         self.fields = {key: self.fields[key] for key in ordered_fields if key in self.fields}
         if 'password1' in self.fields:
-            self.fields['password1'].help_text = t('Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character (e.g. @$!%*?&#).')
+            self.fields['password1'].help_text = t('Password must be at least 12 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character (e.g. @$!%*?&#).')
 
     def clean_username(self):
         username = self.cleaned_data.get('username')
@@ -131,8 +131,8 @@ class UserRegistrationForm(UserCreationForm):
         password = self.cleaned_data.get('password1')
         if password:
             import re
-            if len(password) < 8:
-                raise forms.ValidationError(t('Password must be at least 8 characters long.'))
+            if len(password) < 12:
+                raise forms.ValidationError(t('Password must be at least 12 characters long.'))
             if not re.search(r'[A-Z]', password):
                 raise forms.ValidationError(t('Password must contain at least one uppercase letter.'))
             if not re.search(r'[a-z]', password):

--- a/users/tests.py
+++ b/users/tests.py
@@ -4,6 +4,21 @@ from users.forms import UserRegistrationForm
 from hospitals.models import HospitalProfile
 
 class HospitalRegistrationTests(TestCase):
+    def test_donor_registration_rejects_weak_password(self):
+        form_data = {
+            'username': 'donor_weak',
+            'role': 'donor',
+            'first_name': 'John',
+            'last_name': 'Doe',
+            'phone_number': '1234567890',
+            'password1': 'Weak123!',
+            'password2': 'Weak123!',
+        }
+        form = UserRegistrationForm(data=form_data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('password1', form.errors)
+        self.assertIn('12 characters long', form.errors['password1'][0])
+
     def test_donor_registration_validation(self):
         # Verify donor fields validation
         form_data = {
@@ -187,4 +202,3 @@ class CoordinateValidationTests(TestCase):
         req.longitude = Decimal('-180.100000')
         with self.assertRaises(ValidationError):
             req.full_clean()
-


### PR DESCRIPTION
## Summary
- Strengthen registration password validation to require at least 12 characters plus uppercase, lowercase, numeric, and special characters.
- Update the helper text so the UI matches the enforced policy.
- Add a regression test that rejects weak passwords.

## Why
- The previous registration policy only required 8 characters, which left accounts much easier to brute force or guess.

## Validation
- `git diff --check`
- `python manage.py test users.tests.HospitalRegistrationTests --verbosity 2`

## Notes
- This branch also includes the BloodConnect migration-graph repair needed for local Django test execution.

Closes #89
