### PR TITLE
fix: auto-enforce donation cooldown on donor availability_status

### DIFF
--- a/donors/models.py
+++ b/donors/models.py
@@ -53,6 +53,20 @@ class DonorProfile(models.Model):
         from datetime import date, timedelta
         return date.today() - self.last_blood_donation_date > timedelta(days=90)
 
+    def enforce_cooldown(self):
+        if not self.can_donate():
+            if self.availability_status == 'available':
+                self.availability_status = 'cooldown'
+                return True
+        elif self.availability_status == 'cooldown':
+            self.availability_status = 'available'
+            return True
+        return False
+
+    def save(self, *args, **kwargs):
+        self.enforce_cooldown()
+        super().save(*args, **kwargs)
+
 
 class BloodDonationHistory(models.Model):
     donor = models.ForeignKey(DonorProfile, on_delete=models.CASCADE, related_name='donation_history')


### PR DESCRIPTION
The availability_status field was manually managed and did not automatically reflect the 90-day donation cooldown. This change:
1. Adds enforce_cooldown() to DonorProfile that sets status to 'cooldown' when can_donate() returns False
2. Restores status to 'available' once the cooldown period expires
3. Calls enforce_cooldown() automatically on every save()

Closes #83