### PR TITLE
fix: harden CSRF protection with trusted origins and ensure CSRF cookie for AJAX

### DIFF
--- a/blood_requests/views.py
+++ b/blood_requests/views.py
@@ -3,6 +3,8 @@ from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.http import require_POST
 from .models import BloodRequest, DonorResponse
 import json
 
@@ -78,6 +80,7 @@ def requests_json(request):
 
 
 @login_required
+@ensure_csrf_cookie
 def chat_room(request, response_id):
     donor_response = get_object_or_404(DonorResponse, id=response_id)
     seeker = donor_response.blood_request.requester

--- a/bloodconnect/settings.py
+++ b/bloodconnect/settings.py
@@ -170,6 +170,16 @@ if not DEBUG:
     # SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     # SECURE_HSTS_PRELOAD = True
 
+# CSRF hardening: required for AJAX POST (JS reads cookie, sends as X-CSRFToken header)
+CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_SAMESITE = 'Lax'
+CSRF_TRUSTED_ORIGINS = config(
+    'CSRF_TRUSTED_ORIGINS',
+    default='http://localhost:8000,http://127.0.0.1:8000',
+    cast=Csv(),
+)
+
 
 # Google Sheets API (for contact form)
 GOOGLE_SHEETS_CREDENTIALS = config('GOOGLE_SHEETS_CREDENTIALS', default='')


### PR DESCRIPTION
Adds CSRF_TRUSTED_ORIGINS, sets CSRF_COOKIE_HTTPONLY=False (so JS can read it for X-CSRFToken headers), and applies @ensure_csrf_cookie to the chat_room view.

Closes #86